### PR TITLE
Small batches, leads can submit scores late

### DIFF
--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -1,4 +1,11 @@
 // MODULE 2
+const allowedLateEmails = [
+  'vexr.ai3@mail.qco.io',
+  'ivan.arenovich@gmail.com',
+  'bingbang199@gmail.com',
+  'jrwashburn@gmail.com',
+  'anutakisa1986@gmail.com',
+];
 
 // Basic function for Request Evaluations menu item processing
 function requestEvaluationsModule() {
@@ -607,20 +614,17 @@ function processEvaluationResponse(e) {
       return;
     }
 
-    const allowedLateEmails = [
-      'vexr.ai3@mail.qco.io',
-      'ivan.arenovich@gmail.com',
-      'bingbang199@gmail.com',
-      'jrwashburn@gmail.com',
-      'anutakisa1986@gmail.com',
-    ];
-
     // TODO Discuss: why is this filter commented out?
     // confirmed that we are processing late evaluations; putting this back in.
     const { evaluationWindowStart, evaluationWindowEnd } = getEvaluationWindowTimes();
-    if ((responseTime < evaluationWindowStart || responseTime > evaluationWindowEnd) ||
-        ( allowedLateEmails.includes(evaluatorEmail.toLowerCase()) &&
-          timestamp >= evaluationWindowStart && timestamp <= new Date()))
+    if (
+      (responseTime < evaluationWindowStart || responseTime > evaluationWindowEnd) &&
+      !(
+        allowedLateEmails.includes(evaluatorEmail.toLowerCase()) &&
+        responseTime > evaluationWindowStart &&
+        responseTime <= new Date()
+      )
+    ) {
       Logger.log(
         `Evaluation received at ${responseTime} outside the window from ${evaluationWindowStart} to ${evaluationWindowEnd}. Response will be ignored.`
       );
@@ -1007,13 +1011,6 @@ function batchProcessEvaluationResponses() {
     Logger.log(`Evaluation window: ${evaluationWindowStart} to ${evaluationWindowEnd}`);
 
     const formResponses = form.getResponses();
-    const allowedLateEmails = [
-      'vexr.ai3@mail.qco.io',
-      'ivan.arenovich@gmail.com',
-      'bingbang199@gmail.com',
-      'jrwashburn@gmail.com',
-      'anutakisa1986@gmail.com',
-    ];
     const filteredResponses = formResponses.filter((response) => {
       const timestamp = new Date(response.getTimestamp());
       const respondentEmail = response.getRespondentEmail().toLowerCase();

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -607,10 +607,20 @@ function processEvaluationResponse(e) {
       return;
     }
 
+    const allowedLateEmails = [
+      'vexr.ai3@mail.qco.io',
+      'ivan.arenovich@gmail.com',
+      'bingbang199@gmail.com',
+      'jrwashburn@gmail.com',
+      'anutakisa1986@gmail.com',
+    ];
+
     // TODO Discuss: why is this filter commented out?
     // confirmed that we are processing late evaluations; putting this back in.
     const { evaluationWindowStart, evaluationWindowEnd } = getEvaluationWindowTimes();
-    if (responseTime < evaluationWindowStart || responseTime > evaluationWindowEnd) {
+    if ((responseTime < evaluationWindowStart || responseTime > evaluationWindowEnd) ||
+        ( allowedLateEmails.includes(evaluatorEmail.toLowerCase()) &&
+          timestamp >= evaluationWindowStart && timestamp <= new Date()))
       Logger.log(
         `Evaluation received at ${responseTime} outside the window from ${evaluationWindowStart} to ${evaluationWindowEnd}. Response will be ignored.`
       );

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -5,6 +5,7 @@ const allowedLateEmails = [
   'bingbang199@gmail.com',
   'jrwashburn@gmail.com',
   'anutakisa1986@gmail.com',
+  'shpeht@gmail.com',
 ];
 
 // Basic function for Request Evaluations menu item processing

--- a/Module5-ConflictResolutionTeam.js
+++ b/Module5-ConflictResolutionTeam.js
@@ -58,14 +58,6 @@ function selectCRTMembers() {
   // Log selected ambassadors and date in CRT sheet
   const selectionDate = new Date();
   crtSheet.appendRow([selectionDate, ...selectedAmbassadors]);
-
-  // Notify selected ambassadors via email
-  if (SEND_EMAIL) {
-    selectedAmbassadors.forEach((ambassador) => {
-      sendCRTNotification(ambassador, CRT_SELECTING_NOTIFICATION_TEMPLATE); // Helper function for sending emails
-      Logger.log(`Notification sent to CRT member: ${ambassador}`);
-    });
-  }
 }
 
 /**
@@ -102,17 +94,4 @@ function getRandomSelection(array, num) {
     selected.push(array.splice(randomIndex, 1)[0]); // Remove and select random element
   }
   return selected;
-}
-
-/**
- * Sends a notification email to a selected CRT member.
- * @param {string} email - Email of the CRT member.
- * @param {string} template - Email template.
- */
-function sendCRTNotification(email, template) {
-  if (!email) {
-    Logger.log('Skipping notification: no email provided.');
-    return;
-  }
-  MailApp.sendEmail(email, 'CRT Selection Notification', template);
 }

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -439,8 +439,6 @@ function getReviewLogAssignments() {
       assignments[submitterEmail] = evaluators;
     }
   });
-
-  Logger.log(`Review Log assignments: ${JSON.stringify(assignments)}`);
   return assignments;
 }
 

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -144,11 +144,6 @@ Dear Ambassador,
 By this we notify you about upcoming Peer Review mailing, please be vigilant!
 `;
 
-//"CRT Selecting Notification" email template
-let CRT_SELECTING_NOTIFICATION_TEMPLATE = `
-Dear Ambassador, you have been selected for next Conflict Resolution Team ...
-`;
-
 // EXEMPTION FROM EVALUATION e-mail template
 let EXEMPTION_FROM_EVALUATION_TEMPLATE = `
 Dear Ambassador, you have been relieved of the obligation to evaluate your colleagues this month.


### PR DESCRIPTION
1) Batch Process fails because it takes too long to execute. To resolve this PR breaks down batches to just handle 50 evaluations at a time, and repeats until complete.

2) Because there was not a timestamp on the submission and evaluation deadlines in the past, some ambassadors submitted on the dead line day, but a few hours late. Because of this, they were not included in evaluations. Because the time was not clear, we opted to have leads go ahead and score those same-day submissions. To be able to process those, we have to relax the end date for leads temporarily. 

After this score is updated, we can revert the carve-out for the next cycle.