### PR TITLE
Revert allow late reviews

### DIFF
--- a/Module1-Submissions.js
+++ b/Module1-Submissions.js
@@ -32,6 +32,13 @@ function requestSubmissionsModule() {
 
   // Get deliverable date of the reporting month at first time (previous month date)
   const deliverableDate = getPreviousMonthDate();
+  // TODO REMOVE after January submissions are requested.
+  // temporary processing - if deliverable date is February 2025, push back to January.
+  // dumb kludge because we operate on the assumption that you are requesting from last month.
+  // prefer to keep the assumption over making the user enter the period.
+  if (deliverableDate.getFullYear() == 2025 && deliverableDate.getMonth() == 1) {
+    deliverableDate.setMonth(deliverableDate.getMonth() - 1);
+  }
   Logger.log(`Deliverable date: ${deliverableDate}`);
 
   const month = Utilities.formatDate(deliverableDate, spreadsheetTimeZone, 'MMMM'); // Format the deliverable date to get the month name

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -1040,7 +1040,7 @@ function batchProcessEvaluationResponses() {
       Logger.log(`Processed batch. Next batch will start from index: ${newLastProcessedIndex}`);
     } else {
       properties.deleteProperty('lastProcessedIndex');
-      deleteBatchProcessingTrigger();
+      deleteBatchProcessingTriggers();
       Logger.log('Batch processing of evaluation responses completed.');
     }
   } catch (error) {
@@ -1048,11 +1048,12 @@ function batchProcessEvaluationResponses() {
   }
 }
 
-function deleteBatchProcessingTrigger() {
+function deleteBatchProcessingTriggers() {
   const triggers = ScriptApp.getProjectTriggers();
-  const currentTrigger = triggers.find((trigger) => trigger.getHandlerFunction() === 'batchProcessEvaluationResponses');
-  if (currentTrigger) {
-    ScriptApp.deleteTrigger(currentTrigger);
-    Logger.log('Deleted current batch processing trigger.');
-  }
+  triggers.forEach((trigger) => {
+    if (trigger.getHandlerFunction() === 'batchProcessEvaluationResponses') {
+      ScriptApp.deleteTrigger(trigger);
+      Logger.log('Deleted batch processing trigger.');
+    }
+  });
 }

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -1,13 +1,4 @@
 // MODULE 2
-const allowedLateEmails = [
-  'vexr.ai3@mail.qco.io',
-  'ivan.arenovich@gmail.com',
-  'bingbang199@gmail.com',
-  'jrwashburn@gmail.com',
-  'anutakisa1986@gmail.com',
-  'shpeht@gmail.com',
-];
-
 // Basic function for Request Evaluations menu item processing
 function requestEvaluationsModule() {
   const evaluationWindowStart = new Date(); // Capture start time for the evaluation window
@@ -618,14 +609,7 @@ function processEvaluationResponse(e) {
     // TODO Discuss: why is this filter commented out?
     // confirmed that we are processing late evaluations; putting this back in.
     const { evaluationWindowStart, evaluationWindowEnd } = getEvaluationWindowTimes();
-    if (
-      (responseTime < evaluationWindowStart || responseTime > evaluationWindowEnd) &&
-      !(
-        allowedLateEmails.includes(evaluatorEmail.toLowerCase()) &&
-        responseTime > evaluationWindowStart &&
-        responseTime <= new Date()
-      )
-    ) {
+    if (responseTime < evaluationWindowStart || responseTime > evaluationWindowEnd) {
       Logger.log(
         `Evaluation received at ${responseTime} outside the window from ${evaluationWindowStart} to ${evaluationWindowEnd}. Response will be ignored.`
       );
@@ -1014,11 +998,7 @@ function batchProcessEvaluationResponses() {
     const formResponses = form.getResponses();
     const filteredResponses = formResponses.filter((response) => {
       const timestamp = new Date(response.getTimestamp());
-      const respondentEmail = response.getRespondentEmail().toLowerCase();
-      const isWithinWindow = timestamp >= evaluationWindowStart && timestamp <= evaluationWindowEnd;
-      const isAllowedLateResponse =
-        allowedLateEmails.includes(respondentEmail) && timestamp >= evaluationWindowStart && timestamp <= new Date();
-      return isWithinWindow || isAllowedLateResponse;
+      return timestamp >= evaluationWindowStart && timestamp <= evaluationWindowEnd;
     });
 
     Logger.log(`Total form responses to process: ${filteredResponses.length}`);


### PR DESCRIPTION
1. Reverting code that was temporarily added to allow leads to provide late reviews for those that may have missed deadline because the time was not specified.

Going forward, the time will be explicit and late reviews will not be allowed.

2. Adding another temporary kludge to allow requesting late submissions (in March, for January instead of expected February.) This will be merged, then again removed as soon as Sponsor requests January submissions.

3. Changing the batch processing delete triggers to delete all triggers, not just the current.