### PR TITLE
Add Primary team

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 appengine-generated/
 .DS_Store
 *.clasp.json
+
+.idea/

--- a/EnvironmentVariablesProd.js
+++ b/EnvironmentVariablesProd.js
@@ -39,6 +39,7 @@ function setProductionVariables() {
   AMBASSADOR_EMAIL_COLUMN = 'Ambassador Email Address';
   AMBASSADOR_DISCORD_HANDLE_COLUMN = 'Ambassador Discord Handle';
   AMBASSADOR_STATUS_COLUMN = 'Ambassador Status';
+  AMBASSADOR_PRIMARY_TEAM_COLUMN = 'Primary Team';
   GOOGLE_FORM_TIMESTAMP_COLUMN = 'Timestamp';
   SUBM_FORM_USER_PROVIDED_EMAIL_COLUMN = 'Email Address';
   EVAL_FORM_USER_PROVIDED_EMAIL_COLUMN = 'Email Address';

--- a/EnvironmentVariablesTest.js
+++ b/EnvironmentVariablesTest.js
@@ -37,6 +37,7 @@ function setTestVariables() {
     AMBASSADOR_EMAIL_COLUMN = 'Ambassador Email Address';
     AMBASSADOR_DISCORD_HANDLE_COLUMN = 'Ambassador Discord Handle';
     AMBASSADOR_STATUS_COLUMN = 'Ambassador Status';
+    AMBASSADOR_PRIMARY_TEAM_COLUMN = 'Primary Team';
     GOOGLE_FORM_TIMESTAMP_COLUMN = 'Timestamp';
     SUBM_FORM_USER_PROVIDED_EMAIL_COLUMN = 'Your Email Address';
     EVAL_FORM_USER_PROVIDED_EMAIL_COLUMN = 'Your Email Address';
@@ -108,6 +109,7 @@ Please add links your contributions during the month `;
     AMBASSADOR_EMAIL_COLUMN = 'Ambassador Email Address';
     AMBASSADOR_DISCORD_HANDLE_COLUMN = 'Ambassador Discord Handle';
     AMBASSADOR_STATUS_COLUMN = 'Ambassador Status';
+    AMBASSADOR_PRIMARY_TEAM_COLUMN = 'Primary Team';
     GOOGLE_FORM_TIMESTAMP_COLUMN = 'Timestamp';
     SUBM_FORM_USER_PROVIDED_EMAIL_COLUMN = 'Email';
     EVAL_FORM_USER_PROVIDED_EMAIL_COLUMN = 'Email';

--- a/EnvironmentVariablesTest.js
+++ b/EnvironmentVariablesTest.js
@@ -78,7 +78,7 @@ Please add links your contributions during the month `;
     //
     //
   } else if (TESTER === 'Jonathan') {
-    SEND_EMAIL = false;
+    SEND_EMAIL = true;
 
     // Specify your testing sheets/forms/etc. here:
     // Spreadsheets:

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -144,8 +144,8 @@ function createMonthSheetAndOverallColumn() {
 function updateEvaluationFormQuestions() {
   const form = FormApp.openById(EVALUATION_FORM_ID);
   const items = form.getItems();
-  items.forEach(item => {
-    if (item.getTitle().includes("Please assign a grade")) {
+  items.forEach((item) => {
+    if (item.getTitle().includes('Please assign a grade')) {
       item.setHelpText(
         `Please consider the ambassador's contributions in relation to their primary team when making your assessment.`
       );
@@ -395,7 +395,8 @@ function sendEvaluationRequests() {
             .replace('{SubmissionsList}', contributionDetails)
             .replace('{EvaluationFormURL}', EVALUATION_FORM_URL)
             .replace('{EVALUATION_DEADLINE_DATE}', evaluationDeadlineDate)
-            .replace('{PrimaryTeam}', primaryTeam);
+            .replace('{PrimaryTeam}', primaryTeam)
+            .replace('{PrimaryTeamResponsibilities}', getPrimaryTeamResponsibilities(primaryTeam));
 
           if (SEND_EMAIL) {
             MailApp.sendEmail({
@@ -516,7 +517,7 @@ function getAmbassadorPrimaryTeam(email) {
     // Open the Registry spreadsheet
     const registrySpreadsheet = SpreadsheetApp.openById(AMBASSADOR_REGISTRY_SPREADSHEET_ID);
     const registrySheet = registrySpreadsheet.getSheetByName(REGISTRY_SHEET_NAME);
-    
+
     if (!registrySheet) {
       Logger.log('Error: Registry spreadsheet not found');
       return '';
@@ -525,16 +526,16 @@ function getAmbassadorPrimaryTeam(email) {
     // Get all data from the Registry spreadsheet
     const registryData = registrySheet.getDataRange().getValues();
     const headerRow = registryData[0];
-    
+
     // Find indices of the columns
     const emailColIndex = headerRow.indexOf(AMBASSADOR_EMAIL_COLUMN);
     const primaryTeamColIndex = headerRow.indexOf(AMBASSADOR_PRIMARY_TEAM_COLUMN);
-    
+
     if (emailColIndex === -1 || primaryTeamColIndex === -1) {
       Logger.log('Error: Required columns not found in the Registry');
       return '';
     }
-    
+
     // Search for the ambassador's email and return their primary team
     for (let i = 1; i < registryData.length; i++) {
       if (registryData[i][emailColIndex].toLowerCase() === email.toLowerCase()) {

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -6,9 +6,6 @@ function requestEvaluationsModule() {
   // Step 1: Create a month sheet and column in the Overall score
   createMonthSheetAndOverallColumn();
 
-  // Step 1.5: Update evaluation form questions
-  updateEvaluationFormQuestions();
-
   // Step 2: Generating the review matrix (submitters and evaluators)
   generateReviewMatrix();
 
@@ -141,13 +138,16 @@ function createMonthSheetAndOverallColumn() {
   }
 }
 
-function updateEvaluationFormQuestions() {
+function updateEvaluationFormQuestions(primaryTeam) {
   const form = FormApp.openById(EVALUATION_FORM_ID);
   const items = form.getItems();
   items.forEach(item => {
     if (item.getTitle().includes("Please assign a grade")) {
-      item.setHelpText("Please consider the ambassador's contributions in relation to their primary team when making your assessment.");
+      item.setHelpText(
+        `Please consider the ambassador's contributions in relation to their primary team when making your assessment.
 
+Ambassador's Primary Team: ${primaryTeam}`
+      );
     }
   });
 }
@@ -381,6 +381,8 @@ function sendEvaluationRequests() {
       Logger.log(`Contribution details: ${contributionDetails}`);
 
       const primaryTeam = getAmbassadorPrimaryTeam(submitterEmail);
+
+      updateEvaluationFormQuestions(primaryTeam);
 
       reviewersEmails.forEach((reviewerEmail) => {
         try {

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -6,8 +6,11 @@ function requestEvaluationsModule() {
   // Step 1: Create a month sheet and column in the Overall score
   createMonthSheetAndOverallColumn();
 
-  // Step 2: Generating the review matrix (submitters and evaluators)
+  // Step 2: Generating the review matrix (submitters   and evaluators)
   generateReviewMatrix();
+
+  // Step 2.5: Update evaluation form questions
+  updateEvaluationFormQuestions();
 
   // Step 3: Sending evaluation requests
   sendEvaluationRequests();
@@ -138,15 +141,13 @@ function createMonthSheetAndOverallColumn() {
   }
 }
 
-function updateEvaluationFormQuestions(primaryTeam) {
+function updateEvaluationFormQuestions() {
   const form = FormApp.openById(EVALUATION_FORM_ID);
   const items = form.getItems();
   items.forEach(item => {
     if (item.getTitle().includes("Please assign a grade")) {
       item.setHelpText(
-        `Please consider the ambassador's contributions in relation to their primary team when making your assessment.
-
-Ambassador's Primary Team: ${primaryTeam}`
+        `Please consider the ambassador's contributions in relation to their primary team when making your assessment.`
       );
     }
   });
@@ -382,8 +383,6 @@ function sendEvaluationRequests() {
 
       const primaryTeam = getAmbassadorPrimaryTeam(submitterEmail);
 
-      updateEvaluationFormQuestions(primaryTeam);
-
       reviewersEmails.forEach((reviewerEmail) => {
         try {
           const evaluatorDiscordHandle = getDiscordHandleFromEmail(reviewerEmail); // Call from SharedUtilities
@@ -395,7 +394,8 @@ function sendEvaluationRequests() {
             .replace('{AmbassadorSubmitter}', submitterDiscordHandle)
             .replace('{SubmissionsList}', contributionDetails)
             .replace('{EvaluationFormURL}', EVALUATION_FORM_URL)
-            .replace('{EVALUATION_DEADLINE_DATE}', evaluationDeadlineDate);
+            .replace('{EVALUATION_DEADLINE_DATE}', evaluationDeadlineDate)
+            .replace('{PrimaryTeam}', primaryTeam);
 
           if (SEND_EMAIL) {
             MailApp.sendEmail({

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -6,6 +6,9 @@ function requestEvaluationsModule() {
   // Step 1: Create a month sheet and column in the Overall score
   createMonthSheetAndOverallColumn();
 
+  // Step 1.5: Update evaluation form questions
+  updateEvaluationFormQuestions();
+
   // Step 2: Generating the review matrix (submitters and evaluators)
   generateReviewMatrix();
 
@@ -136,6 +139,17 @@ function createMonthSheetAndOverallColumn() {
   } catch (error) {
     Logger.log(`Error in createMonthSheetAndOverallColumn: ${error}`);
   }
+}
+
+function updateEvaluationFormQuestions() {
+  const form = FormApp.openById(EVALUATION_FORM_ID);
+  const items = form.getItems();
+  items.forEach(item => {
+    if (item.getTitle().includes("Please assign a grade")) {
+      item.setHelpText("Please consider the ambassador's contributions in relation to their primary team when making your assessment.");
+
+    }
+  });
 }
 
 /**

--- a/Module5-ConflictResolutionTeam.js
+++ b/Module5-ConflictResolutionTeam.js
@@ -39,7 +39,7 @@ function selectCRTMembers() {
 
   // Filter eligible ambassadors
   const eligibleAmbassadors = registryData
-    .filter((row) => !row[statusColumnIndex - 1]?.includes('Expelled')) // Exclude expelled ambassadors
+    .filter((row) => !row[statusColumnIndex - 1]?.toLowerCase().includes('expelled')) // Exclude expelled ambassadors
     .map((row) => row[emailColumnIndex - 1]?.trim().toLowerCase()) // Extract valid emails
     .filter((email) => email && !recentCRTMembers.includes(email)); // Exclude empty emails and recent CRT members
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This app script code can be added to a google sheet to run the Ambassador OS.
 
 ## Some assumptions:
 
-1. You have a google sheet with a list of ambassadors with three columns, Ambassador Email Address, Ambassador Discord Handle, and Ambassador Status.
+1. You have a google sheet with a list of ambassadors with four columns, Ambassador Email Address, Ambassador Discord Handle, and Ambassador Status, Primary Team.
 2. You have a google sheet with a list of ambassador contributions with columns: Timestamp, Email Address, Your Discord Handle, "Dear Ambassador,
    Please add text, inputs or links to your contributions during the month:"
 
@@ -169,6 +169,7 @@ When requesting Evaluations, the script will add a new sheet to the Submissions 
 
 Backup your current "Ambassadors' Scores" spreadsheet.
 In Registry add 3-rd column. Name it "Ambassador Status". Manually write onboarding date of all ambassadors.
+In Registry add 4-rd column. Name it "Primary Team". Manually write onboarding date of all ambassadors.
 Rename sheet 'Overall score ' to 'Overall score' (remove the last space symbol).
 In both Registry and Overall score sheets, add new first column "Ambassador Id" - it can be left empty, just create the column.
 Delete "Sheet 1" sheet in Ambassadors' Scores sprdsht, (if you forget and don't really need it).

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -111,7 +111,13 @@ Ambassador Program Team</p>
 // Request Evaluation Email Template
 let REQUEST_EVALUATION_EMAIL_TEMPLATE = `
 <p>Dear {AmbassadorDiscordHandle},</p>
-<p>Please review the following deliverables for the month of {Month} by {AmbassadorSubmitter}:</p>
+<p>Please review the following deliverables for the month of <strong>{Month}</strong> by:</p>
+
+<p>
+<strong>{AmbassadorSubmitter}<br>
+Primary Team:  {PrimaryTeam} </strong>
+</p>
+
 <p>{SubmissionsList}</p>
 
 <p>Assign a grade using the form:</p>

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -114,10 +114,12 @@ let REQUEST_EVALUATION_EMAIL_TEMPLATE = `
 <p>Please review the following deliverables for the month of <strong>{Month}</strong> by:</p>
 
 <p>
-<strong>{AmbassadorSubmitter}<br>
-Primary Team:  {PrimaryTeam} </strong>
+<strong>{AmbassadorSubmitter}<br><br>
+Primary Team:  {PrimaryTeam}<br><br>
+Primary Team Responsibilities:</strong><br>{PrimaryTeamResponsibilities}<br><br>
 </p>
 
+<strong>Work Submitted:</strong><br>
 <p>{SubmissionsList}</p>
 
 <p>Assign a grade using the form:</p>
@@ -155,6 +157,33 @@ By this we notify you about upcoming Peer Review mailing, please be vigilant!
 let EXEMPTION_FROM_EVALUATION_TEMPLATE = `
 Dear Ambassador, you have been relieved of the obligation to evaluate your colleagues this month.
 `;
+
+// Primary team Responsibilities
+const PrimaryTeamResponsibilities = {
+  support: `Provide peer-to-peer support and create support materials (e.g., articles),<br>
+      Gather information and help investigate and solve technical issues,<br>
+      Assist or directly participate in technical development of the project,<br>
+      Answer questions in Discord, Telegram, and the Networks forum,<br>
+      Moderate Telegram and Discord channels,<br>
+      Communicate about current releases and important events`,
+  content: `Create and improve an educational plan for onboarding new Apprentices,<br>
+      Develop materials, resources, and documentation on the protocol, Program, and community,<br>
+      Create high-quality content to educate the community about the Network,<br>
+      Cultivate content creators by recognizing and promoting users with the Content Creator role`,
+  engagement: `Promote the growth of the Network by establishing connections with the community,<br>
+      Identify target audiences and develop strategies to attract them to the Network,<br>
+      Create and disseminate high-quality content across various platforms,<br>
+      Increase user engagement and encourage active community participation,<br>
+      Act as a voice for the Network, ensuring smooth communication among stakeholders`,
+  onboarding: `Create and administer Ambassador selection processes,<br>
+      Introduce and integrate Apprentices and new Ambassadors to the Program,<br>
+      Recruit new ambassador cohorts and host events/workshops,<br>
+      Mentor Apprentice Ambassadors and develop peer relationships,<br>
+      Collaborate with the Content & Education team to keep Ambassadors updated`,
+  governance: `Create and maintain the Bylaws and facilitate General Assembly operations,<br>
+      Develop transparent systems and processes to implement the Bylaws,<br>
+      Administer processes and evaluate adherence to Ambassador Rights and Obligations`,
+};
 
 //    On Open Menu
 
@@ -884,4 +913,12 @@ function validateHeaders(sheetName, headers, expectedHeaders) {
     }
   }
   return true;
+}
+
+/**
+ * Funciton to get primary team responsibilities to be used in the evaluation email
+ */
+function getPrimaryTeamResponsibilities(primaryTeam) {
+  const teamKey = primaryTeam.toLowerCase();
+  return PrimaryTeamResponsibilities[teamKey] || 'Responsibilities not found for the specified team.';
 }

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -2,7 +2,7 @@
 // Declare & initialize global variables; these will be updated by the setProductionVariables() or setTestVariables() functions
 
 // testing constant will be used to load production vs. test values for the global variables
-const testing = false; // Set to true for testing (logs instead of sending emails, uses test sheets and forms)
+const testing = true; // Set to true for testing (logs instead of sending emails, uses test sheets and forms)
 var SEND_EMAIL; // Will control whether emails are sent - must be true for production; may be true or false for testing depending on testing needs.
 
 // Provide the actual Id of the google sheet for the registry and scoreing sheets in EnvironmentVariables[Prod|Test].js:
@@ -31,6 +31,7 @@ var AMBASSADOR_ID_COLUMN = '';
 var AMBASSADOR_EMAIL_COLUMN = '';
 var AMBASSADOR_DISCORD_HANDLE_COLUMN = '';
 var AMBASSADOR_STATUS_COLUMN = '';
+var AMBASSADOR_PRIMARY_TEAM = '';
 var GOOGLE_FORM_TIMESTAMP_COLUMN = '';
 var GOOGLE_FORM_CONTRIBUTION_DETAILS_COLUMN = '';
 var GOOGLE_FORM_CONTRIBUTION_LINKS_COLUMN = '';


### PR DESCRIPTION
# 🆕 Addition of Ambassador Primary Team

## 📄 Description  
This PR implements the functionality to display and manage the Ambassador's Primary Team in the evaluation system.  
The changes include adding a new column and updating related functions to support this information.

## 🔧 Main Changes  
- ➕ Added new column **"Ambassador Primary Team"** in `SharedUtilities`  
- 🛠 Implemented the `updateEvaluationForQuestions` function to include the Ambassador's Primary Team in the Evaluation Form  
- 🧩 Implemented the `getAmbassadorPrimaryTeam` function to retrieve the team information  
- 🧪 Added new column in `EnvironmentVariableTest` for testing purposes  
-  Updated REAME to reflect the new feature. 

## 📈 Impact  
- ✅ Evaluators can now see the Ambassador's Primary Team during the evaluation process  
- 🌐 Improves transparency and context for evaluations  
- 🟢 No negative impact expected on the existing workflow  

## ✅ Tests  
- ✅ Tests performed in the development environment  
- 🔄 Verified integration with the existing Evaluation Form  
- 👀 Validated correct display of information  
