### PR TITLE
add request log to track submission and evaluation windows

### DIFF
--- a/Module1-Submissions.js
+++ b/Module1-Submissions.js
@@ -152,6 +152,8 @@ function requestSubmissionsModule(month, year) {
 
   // Save the submission window start time in Los Angeles time zone format
   setSubmissionWindowStart(submissionWindowStart);
+  // Log the request in the "Request Log" sheet
+  logRequest('Submission', month, year, submissionWindowStart, submissionDeadline);
 
   // Set a trigger to check for non-respondents and send reminders
   setupSubmissionReminderTrigger(submissionWindowStart);

--- a/Module1-Submissions.js
+++ b/Module1-Submissions.js
@@ -153,7 +153,11 @@ function requestSubmissionsModule(month, year) {
   // Save the submission window start time in Los Angeles time zone format
   setSubmissionWindowStart(submissionWindowStart);
   // Log the request in the "Request Log" sheet
-  logRequest('Submission', month, year, submissionWindowStart, submissionDeadline);
+  try {
+    logRequest('Submission', month, year, submissionWindowStart, submissionDeadline);
+  } catch (error) {
+    Logger.log(`Error logging request: ${error.message}`);
+  }
 
   // Set a trigger to check for non-respondents and send reminders
   setupSubmissionReminderTrigger(submissionWindowStart);

--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -363,6 +363,17 @@ function sendEvaluationRequests() {
     const evaluationWindowStart = new Date();
     const evaluationDeadline = new Date(evaluationWindowStart.getTime() + EVALUATION_WINDOW_MINUTES * 60 * 1000); // Adjust to milliseconds
     const evaluationDeadlineDate = Utilities.formatDate(evaluationDeadline, 'UTC', 'MMMM dd, yyyy HH:mm:ss') + ' UTC';
+    try {
+      logRequest(
+        'Evaluation',
+        Utilities.formatDate(deliverableMonthDate, spreadsheetTimeZone, 'MMMM'),
+        deliverableMonthDate.getFullYear().toString(),
+        evaluationWindowStart,
+        evaluationDeadline
+      );
+    } catch (error) {
+      Logger.log(error);
+    }
 
     reviewData.forEach((row, rowIndex) => {
       const submitterEmail = row[0]; // submitter's email

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -2,7 +2,7 @@
 // Declare & initialize global variables; these will be updated by the setProductionVariables() or setTestVariables() functions
 
 // testing constant will be used to load production vs. test values for the global variables
-const testing = false; // Set to true for testing (logs instead of sending emails, uses test sheets and forms)
+const testing = true; // Set to true for testing (logs instead of sending emails, uses test sheets and forms)
 var SEND_EMAIL; // Will control whether emails are sent - must be true for production; may be true or false for testing depending on testing needs.
 
 // Provide the actual Id of the google sheet for the registry and scoreing sheets in EnvironmentVariables[Prod|Test].js:
@@ -922,4 +922,26 @@ function validateHeaders(sheetName, headers, expectedHeaders) {
 function getPrimaryTeamResponsibilities(primaryTeam) {
   const teamKey = primaryTeam.toLowerCase();
   return PrimaryTeamResponsibilities[teamKey] || 'Responsibilities not found for the specified team.';
+}
+
+function logRequest(type, month, year, requestDateTime, windowEndDateTime) {
+  const spreadsheet = SpreadsheetApp.openById(AMBASSADOR_REGISTRY_SPREADSHEET_ID);
+  let requestLogSheet = spreadsheet.getSheetByName('Request Log');
+
+  // Create the sheet if it doesn't exist
+  if (!requestLogSheet) {
+    requestLogSheet = spreadsheet.insertSheet('Request Log');
+    requestLogSheet.appendRow(['Type', 'Month', 'Year', 'Request Date Time', 'Window End Date Time']);
+  }
+
+  // Append the new request details
+  requestLogSheet.appendRow([
+    type,
+    month,
+    year,
+    Utilities.formatDate(requestDateTime, Session.getScriptTimeZone(), 'yyyy-MM-dd HH:mm:ss'),
+    Utilities.formatDate(windowEndDateTime, Session.getScriptTimeZone(), 'yyyy-MM-dd HH:mm:ss'),
+  ]);
+
+  Logger.log(`Logged ${type} request for ${month} ${year} in "Request Log" sheet.`);
 }


### PR DESCRIPTION
When evaluating whether things were submitted on time, we don't have any place other than email (and partial script settings) to see the submission / evaluation windows.

Adding a request log to keep track of all the windows. 