### PR TITLE
look at latest 6 months for penalty calculation, use last 6 for expulsion

### DIFF
--- a/EnvironmentVariablesProd.js
+++ b/EnvironmentVariablesProd.js
@@ -51,7 +51,7 @@ Please add links to your contributions during the month`;
   GOOGLE_FORM_EVALUATION_HANDLE_COLUMN = 'Discord handle of the ambassador you are evaluating? (Not your own D-Handle)'; //values must match google form questions
   GOOGLE_FORM_EVALUATION_GRADE_COLUMN = 'Please assign a grade on a scale of 0 to 5 '; //trailing space is important.
   GOOGLE_FORM_EVALUATION_REMARKS_COLUMN = 'Remarks (required)';
-  SCORE_PENALTY_POINTS_COLUMN = 'Penalty Points';
+  SCORE_PENALTY_POINTS_COLUMN = 'Penalty Points Last 6 Months';
   SCORE_AVERAGE_SCORE_COLUMN = 'Average Score';
   SCORE_MAX_6M_PP_COLUMN = 'Max 6-Month PP';
   GRADE_SUBMITTER_COLUMN = 'Submitter';

--- a/Module3-Compliance.js
+++ b/Module3-Compliance.js
@@ -568,13 +568,12 @@ function sendExpulsionNotifications(discordHandle) {
     }
 
     const subject = 'Expulsion from the Program';
-    const body = EXPULSION_EMAIL_TEMPLATE.replace('{AmbassadorEmail}', email);
     const sponsorBody = `Ambassador ${email} (${discordHandle}) has been expelled from the program.`;
 
     // Send notification to the expelled ambassador using generic email function
     // Not sending automatically until March evaluations are completed per governance.
     // Will still notify Sponsor for evaluation.
-    // sendEmailNotification(email, subject, body);
+    // sendEmailNotification(email, subject, EXPULSION_EMAIL_TEMPLATE);
     Logger.log(`Expulsion email [TEMPORARILY NOT] sent to ${email}.`);
 
     // Send notification to the sponsor using generic email function


### PR DESCRIPTION
Changed penalty point calculation to look back at last 6 months.

Prior to these changes, the penatly points column was only for the last month, and the max penalty 6 months looked at _any_ rolling six month period. This included periods long past that were prior to bylaws changes. Those periods should not be considered for the expulsion criteria. 

This change updates the penalty points column to look at the most recent 6 months of scoring, and changes expulsion to look at the most recent 6 months as well. 

I left the max 6 months calculation there because it may be interesting for future CRT, etc. 

I also changed the way expulsions skip emailing the ambassador. We are not going to be automatically expelling ambassadors until the March evals. But for this cycle, we will email the expulsion notice to the sponsor so that a) we can check them for consideration, and b) we can see what the emails are going to look like once we start the automation. 