### PR TITLE
normalize email and use it throughout for email comparisons

### DIFF
--- a/ColumnsCreating.js
+++ b/ColumnsCreating.js
@@ -56,7 +56,7 @@ function syncRegistryColumnsToOverallScore() {
     // Sync "Ambassadors' Discord Handles" and "Ambassador Id"
     for (let i = 1; i < registryData.length; i++) {
       let ambassadorId = registryData[i][registryAmbassadorIdColumnIndex - 1]; // Ambassador Id from registry
-      const email = registryData[i][registryEmailColumnIndex - 1]?.trim().toLowerCase(); // Ensure email is lowercased and trimmed
+      const email = normalizeEmail(registryData[i][registryEmailColumnIndex - 1]); // Ensure email is lowercased and trimmed
       const discordHandle = registryData[i][registryDiscordColumnIndex - 1]; // Discord Handle
       const registryAmbassadorStatus = registryData[i][registryStatusColumnIndex - 1]; // Ambassador Status
 

--- a/Module1-Submissions.js
+++ b/Module1-Submissions.js
@@ -99,7 +99,7 @@ function requestSubmissionsModule(month, year) {
   // Filter out ambassadors with 'Expelled' in their status
   const eligibleEmails = registryData
     .filter((row) => !row[registryAmbassadorStatus - 1].toLowerCase().includes('expelled')) // Exclude expelled ambassadors - case-insensitive now
-    .map((row) => [row[registryEmailColIndex - 1], row[registryAmbassadorDiscordHandle - 1]]); // Extract only emails
+    .map((row) => [normalizeEmail(row[registryEmailColIndex - 1]), row[registryAmbassadorDiscordHandle - 1]]); // Extract only emails
   Logger.log(`Eligible ambassadors emails: ${JSON.stringify(eligibleEmails)}`);
 
   // Calculate the exact deadline date based on submission window
@@ -211,7 +211,7 @@ function checkNonRespondents() {
     .getValues();
   const eligibleEmails = registryData
     .filter((row) => !row[registryAmbassadorStatusColIndex - 1].toLowerCase().includes('expelled')) // Case-insensitive check
-    .map((row) => row[registryEmailColIndex - 1]);
+    .map((row) => normalizeEmail(row[registryEmailColIndex - 1]));
 
   Logger.log(`Eligible emails: ${eligibleEmails}`);
 
@@ -226,7 +226,7 @@ function checkNonRespondents() {
     return timestamp >= submissionWindowStart && timestamp <= submissionWindowEnd;
   });
 
-  const respondedEmails = validResponses.map((row) => row[responseEmailColIndex - 1]);
+  const respondedEmails = validResponses.map((row) => normalizeEmail(row[responseEmailColIndex - 1]));
   Logger.log(`Responded emails: ${respondedEmails}`);
 
   // Identify non-respondents

--- a/Module3-Compliance.js
+++ b/Module3-Compliance.js
@@ -259,7 +259,7 @@ function calculatePenaltyPoints() {
   const ambassadorData = registryData
     .filter((row) => row[registryEmailColumn]?.trim() && !row[registryStatusColumn]?.toLowerCase().includes('expelled'))
     .map((row) => ({
-      email: row[registryEmailColumn].trim().toLowerCase(),
+      email: normalizeEmail(row[registryEmailColumn]),
       discordHandle: row[registryDiscordColumn]?.trim().toLowerCase(),
     }));
 
@@ -311,9 +311,11 @@ function calculatePenaltyPoints() {
       // if processing current month, first color-code the nonEvaluators and non-submitters
       if (colIndex === currentMonthColIndex) {
         Logger.log(`Processing current month column (${colIndex}) for ${discordHandle}`);
-        const isNonSubmitter = !validSubmitters.includes(email);
+        const isNonSubmitter = !validSubmitters.map(normalizeEmail).includes(normalizeEmail(email));
         const isNonEvaluator = Object.values(assignments).some(
-          (evaluators) => evaluators.includes(email) && !validEvaluators.includes(email)
+          (evaluators) =>
+            evaluators.map(normalizeEmail).includes(normalizeEmail(email)) &&
+            !validEvaluators.map(normalizeEmail).includes(normalizeEmail(email))
         );
 
         const currentCell = overallScoresSheet.getRange(rowInScores, currentMonthColIndex);

--- a/Module4-AdvanceNotice.js
+++ b/Module4-AdvanceNotice.js
@@ -21,7 +21,7 @@ function notifyUpcomingPeerReview() {
     // Filter out ambassadors with 'Expelled' in their status
     const eligibleEmails = registryData
       .filter((row) => !row[statusColumnIndex - 1]?.includes('Expelled')) // Exclude expelled ambassadors
-      .map((row) => row[emailColumnIndex - 1]?.trim()) // Extract valid emails
+      .map((row) => normalizeEmail(row[emailColumnIndex - 1])) // Extract valid emails
       .filter((email) => email); // Exclude empty emails
 
     // Get the email template

--- a/Module5-ConflictResolutionTeam.js
+++ b/Module5-ConflictResolutionTeam.js
@@ -40,8 +40,8 @@ function selectCRTMembers() {
   // Filter eligible ambassadors
   const eligibleAmbassadors = registryData
     .filter((row) => !row[statusColumnIndex - 1]?.toLowerCase().includes('expelled')) // Exclude expelled ambassadors
-    .map((row) => row[emailColumnIndex - 1]?.trim().toLowerCase()) // Extract valid emails
-    .filter((email) => email && !recentCRTMembers.includes(email)); // Exclude empty emails and recent CRT members
+    .map((row) => normalizeEmail(row[emailColumnIndex - 1])) // Extract valid emails
+    .filter((email) => email && !recentCRTMembers.map(normalizeEmail).includes(email)); // Exclude empty emails and recent CRT members
 
   Logger.log(`Eligible ambassadors emails: ${JSON.stringify(eligibleAmbassadors)}`);
 

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -388,6 +388,35 @@ function logEmailNotSent(recipientEmail, subject, bcc, cc) {
   }
 }
 
+/**
+ * Normalizes an email address to a consistent format.
+ * - Converts to lowercase.
+ * - For Gmail addresses, removes dots from the local part.
+ * @param {string} email - The email address to normalize.
+ * @returns {string|null} The normalized email address, or null if the input is invalid.
+ */
+function normalizeEmail(email) {
+  if (!email || typeof email !== 'string') {
+    return email;
+  }
+
+  let trimmedEmail = email.trim().toLowerCase();
+  const atIndex = trimmedEmail.lastIndexOf('@');
+
+  if (atIndex === -1) {
+    return trimmedEmail; // Return as-is if not a valid email format
+  }
+
+  const localPart = trimmedEmail.substring(0, atIndex);
+  const domain = trimmedEmail.substring(atIndex);
+
+  if (domain === '@gmail.com') {
+    return `${localPart.replace(/\./g, '')}${domain}`;
+  }
+
+  return trimmedEmail;
+}
+
 //     Submission/Evaluation WINDOW TIME SET/GET
 
 // Save the submission window start time (in PST)

--- a/check-emails.js
+++ b/check-emails.js
@@ -32,7 +32,7 @@ function validateEmailsInSubmissionForm(formResponseSheetId, registrySheetId) {
       )
       .getValues()
       .flat()
-      .map((email) => email.trim().toLowerCase());
+      .map((email) => normalizeEmail(email));
     Logger.log(`Loaded ${registryEmails.length} emails from the Registry.`);
 
     // Get headers and column indices dynamically
@@ -52,7 +52,7 @@ function validateEmailsInSubmissionForm(formResponseSheetId, registrySheetId) {
 
     allRows.forEach((row, index) => {
       const timestamp = new Date(row[timestampColumnIndex - 1]);
-      const email = row[emailColumnIndex - 1]?.trim().toLowerCase();
+      const email = normalizeEmail(row[emailColumnIndex - 1]);
 
       const isWithinWindow = timestamp >= submissionWindowStart && timestamp <= submissionWindowEnd;
       const isValidEmail = registryEmails.includes(email);


### PR DESCRIPTION
Adds handling to match j.doe and jdoe as the same account under gmail.
(This was the cause of an ambassadors auto-eviction under the failure to participate rules.) 

These changes will match emails by ignoring the period for gmail. 

Updated all email comparisons or uses to call a new shared normalize function.
