### PR TITLE
May updates

### DIFF
--- a/Module2-Evaluations.js
+++ b/Module2-Evaluations.js
@@ -146,8 +146,7 @@ function updateEvaluationFormQuestions(primaryTeam) {
   items.forEach((item) => {
     if (item.getTitle().includes('Please assign a grade')) {
       item.setHelpText(
-        `Please consider the ambassador's contributions in relation to their primary team when making your assessment.
-        Ambassador's Primary Team: ${primaryTeam}`
+        `Please consider the ambassador's contributions in relation to their primary team when making your assessment.`
       );
     }
   });

--- a/Module3-Compliance.js
+++ b/Module3-Compliance.js
@@ -554,8 +554,23 @@ function sendExpulsionNotifications(discordHandle) {
     const subject = 'Expulsion from the Program';
     const sponsorBody = `Ambassador ${email} (${discordHandle}) has been expelled from the program for Failure to Participate according to Article 2, Section 10 of the Bylaws.`;
 
+    // Prepare variables for expulsion email template
+    const currentDate = new Date();
+    const timeZone = getProjectTimeZone();
+    const expulsionDate = Utilities.formatDate(currentDate, timeZone, 'MMMM dd, yyyy');
+
+    // Note: Start date is not currently tracked in the registry
+    // Using a placeholder message until a start date column is added
+    const startDate = 'your start date'; // TODO: Add start date tracking to registry
+
+    // Replace template tokens in the expulsion email
+    let expulsionEmailBody = EXPULSION_EMAIL_TEMPLATE.replace(/{Discord Handle}/g, discordHandle)
+      .replace(/{Expulsion Date}/g, expulsionDate)
+      .replace(/{Start Date}/g, startDate)
+      .replace(/{Sponsor Email}/g, SPONSOR_EMAIL);
+
     // Send notification to the expelled ambassador using generic email function
-    sendEmailNotification(email, subject, EXPULSION_EMAIL_TEMPLATE);
+    sendEmailNotification(email, subject, expulsionEmailBody);
     Logger.log(`Expulsion email sent to ${email}.`);
 
     // Send notification to the sponsor using generic email function

--- a/SharedUtilities.js
+++ b/SharedUtilities.js
@@ -155,9 +155,14 @@ You have been assessed one penalty point for failing to meet Submission or Evalu
 
 // Expulsion Email Template
 let EXPULSION_EMAIL_TEMPLATE = `
-Dear Ambassador,
-We regret to inform you that you have been expelled from the program for Failure to Participate according to Article 2, Section 10 of the Bylaws.
-`;
+Dear {Discord Handle},
+We regret to inform you that you have been expelled from the program for Failure to Participate according to Article 2, Section 10 of the Bylaws as of {Expulsion Date}.
+
+If you believe the expulsion is incorrect, you have the right to appeal your expulsion through the Conflict Resolution Team. Please email the Sponsor Representative at {Sponsor Email} including the reason for your appeal and any supporting documentation that the CRT should consider if you choose to appeal.
+
+We acknowledge and thank you for your contributions to the project as an Ambassador from {Start Date} to {Expulsion Date}.
+
+Autonomys Community Team`;
 
 // Notify Upcoming Peer Review Email Template
 let NOTIFY_UPCOMING_PEER_REVIEW = `


### PR DESCRIPTION
1) Remove primary team note from google form (the same form is sent to all ambassadors, so the reference is not valid.

2) Change the automatic expulsion email to be friendlier and communicate clearly the ability to  appeal as per Governance V: 2025-07-28 https://discord.com/channels/864285291518361610/1396990176844320920/1396991217975300176
